### PR TITLE
DOC: optimize: QAP documentation adjustments

### DIFF
--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -100,7 +100,7 @@ def test_rand_qap():
 
     # check ofv with 100 random initializations
     res = quadratic_assignment(
-        cost_matrix, dist_matrix, options={'init_weight': 0.5, 'init_n': 100}
+        cost_matrix, dist_matrix, options={'init_weight': 0.5, 'init_k': 100}
     )
 
     assert 11156 <= res['score'] < 14500
@@ -114,13 +114,13 @@ def test_quadratic_assignment_input_validation():
     # correct type
 
     with pytest.raises(TypeError):
-        quadratic_assignment(A, B, options={'init_n': 1.5})
+        quadratic_assignment(A, B, options={'init_k': 1.5})
     with pytest.raises(ValueError):
-        quadratic_assignment(A, B, options={'init_n': -1})
+        quadratic_assignment(A, B, options={'init_k': -1})
     with pytest.raises(ValueError):
         quadratic_assignment(A, B, options={'init_weight': 2})
     with pytest.raises(ValueError):
-        quadratic_assignment(A, B, options={'init': "random"})
+        quadratic_assignment(A, B, options={'init_J': "random"})
     with pytest.raises(TypeError):
         quadratic_assignment(A, B, options={'maxiter': 1.5})
     with pytest.raises(ValueError):
@@ -185,7 +185,7 @@ def test_quadratic_assignment_input_validation():
     # test init matrix not doubly stochastic
     with pytest.raises(ValueError):
         quadratic_assignment(
-            np.identity(3), np.identity(3), options={'init': np.ones((3, 3))}
+            np.identity(3), np.identity(3), options={'init_J': np.ones((3, 3))}
         )
 
 


### PR DESCRIPTION
As you've probably noticed, I'm not very familiar with QAP. Please take these suggestions with a grain of salt - I think they would have helped me put together a better mental model as a new `quadratic_assignent` user, but please help me adjust them if they are not appropriate for QAP experts.

I added comments to indicate what I was thinking. We can pick and choose which to keep.

Once we finish with the documentation, I'll also take a quick look at the code, but I don't expect anything new/major there. I'll probably spend the most effort on input validation and unit tests rather than the algorithm. Finally, I'll try to merge scipy/scipy#12161 into this. I do think we need to do these together - or scipy/scipy#12161 first - because generally SciPy needs to have the well-established algorithm, even if it's not the best and brightest. Then, the benchmarks will show why FAQ should be included, too.